### PR TITLE
Add scripts for dataset preparation, inference and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# STT_dataset_preparation_Ru
+# STT Dataset Preparation (Ru)
+
+Scripts extracted from the original notebook to prepare Russian speech datasets for NVIDIA Canary.
+
+## 1. Download dataset
+```
+python download_dataset.py <dataset_repo> --split <split> --out <out_dir> [--hf-token YOUR_TOKEN]
+```
+The script downloads a HuggingFace dataset split, filters Russian samples, converts audio to 16kHz mono WAV and writes a `manifest.jsonl` file.
+
+## 2. Run Canary inference
+```
+python canary_inference.py <manifest.jsonl> --out preds.jsonl
+```
+Loads the Canary model and writes predictions vs reference text for each audio file.
+
+## 3. Analyse predictions
+```
+python dataset_analysis.py preds.jsonl
+```
+Prints word error rate (WER) and sentence error rate (SER) for the predictions file.

--- a/canary_inference.py
+++ b/canary_inference.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from nemo.collections.asr.models import ASRModel
+from tqdm import tqdm
+
+
+def load_canary(model_id: str, nemo_path: str | None):
+    if nemo_path:
+        return ASRModel.restore_from(nemo_path).eval()
+    return ASRModel.from_pretrained(model_name=model_id).eval()
+
+
+def transcribe_paths(model: ASRModel, paths: List[str], batch_size: int,
+                     source_lang: str, target_lang: str, task: str, pnc: bool):
+    results = {}
+    batch_size = max(1, int(batch_size))
+    import torch, gc
+    for i in range(0, len(paths), batch_size):
+        batch = paths[i:i + batch_size]
+        hyps = model.transcribe(batch, batch_size=batch_size,
+                                source_lang=source_lang, target_lang=target_lang,
+                                task=task, pnc=pnc)
+        for p, h in zip(batch, hyps):
+            if isinstance(h, str):
+                results[p] = h
+            elif isinstance(h, dict):
+                results[p] = h.get("text") or h.get("pred_text") or str(h)
+            else:
+                results[p] = str(h)
+        try:
+            torch.cuda.empty_cache(); torch.cuda.ipc_collect()
+        except Exception:  # pragma: no cover - CPU path
+            pass
+        gc.collect()
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run Canary inference and save preds vs refs")
+    parser.add_argument("manifest", help="Path to manifest.jsonl produced by download_dataset.py")
+    parser.add_argument("--out", default="predictions.jsonl")
+    parser.add_argument("--model-id", default="nvidia/canary-1b-v2")
+    parser.add_argument("--nemo-path", default=None)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--source-lang", default="ru")
+    parser.add_argument("--target-lang", default="ru")
+    parser.add_argument("--task", default="asr")
+    parser.add_argument("--pnc", action="store_true", help="Enable punctuation and casing")
+    args = parser.parse_args()
+
+    items = [json.loads(x) for x in Path(args.manifest).open("r", encoding="utf-8")]
+    uniq_paths = list({it["audio_filepath"] for it in items})
+    model = load_canary(args.model_id, args.nemo_path)
+    preds = transcribe_paths(model, uniq_paths, args.batch_size,
+                             args.source_lang, args.target_lang, args.task, args.pnc)
+
+    with Path(args.out).open("w", encoding="utf-8") as f:
+        for it in tqdm(items, desc="write"):
+            hyp = preds.get(it["audio_filepath"], "")
+            row = {"audio": it["audio_filepath"], "ref": it.get("text", ""), "hyp": hyp}
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    print(f"Saved predictions to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dataset_analysis.py
+++ b/dataset_analysis.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+from pathlib import Path
+
+from jiwer import wer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute WER and SER for predictions")
+    parser.add_argument("predictions", help="JSONL with fields: audio, ref, hyp")
+    args = parser.parse_args()
+
+    refs = []
+    hyps = []
+    total = 0
+    wrong = 0
+    with Path(args.predictions).open("r", encoding="utf-8") as f:
+        for line in f:
+            row = json.loads(line)
+            ref = row.get("ref") or row.get("text") or ""
+            hyp = row.get("hyp") or row.get("pred_text") or ""
+            refs.append(ref)
+            hyps.append(hyp)
+            total += 1
+            if ref.strip() != hyp.strip():
+                wrong += 1
+    w = wer(refs, hyps) if refs else 0.0
+    ser = wrong / total if total else 0.0
+    print(f"WER: {w:.4f}")
+    print(f"SER: {ser:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/download_dataset.py
+++ b/download_dataset.py
@@ -1,0 +1,114 @@
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from datasets import load_dataset, Audio
+from tqdm import tqdm
+
+MIN_DUR = 1.0
+MAX_DUR = 35.0
+
+def sha1_name(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8", errors="ignore")).hexdigest()
+
+def ensure_wav_mono16k(data: np.ndarray, sr: int):
+    """Return mono float32 audio resampled to 16 kHz."""
+    if getattr(data, "ndim", 1) > 1:
+        data = data.mean(axis=1)
+    data = np.asarray(data, dtype=np.float32)
+    if sr != 16000:
+        try:
+            import librosa
+            data = librosa.resample(y=data, orig_sr=sr, target_sr=16000)
+            sr = 16000
+        except Exception as exc:  # pragma: no cover - fallback path
+            raise RuntimeError("Need resample to 16k but librosa not available") from exc
+    return data, 16000
+
+def save_wav(path: Path, data: np.ndarray, sr: int):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), data, sr, subtype="PCM_16", format="WAV")
+
+def prepare_hf_dataset_to_wav(repo: str, split: str, out_root: Path,
+                              lang_regex: re.Pattern | None, hf_token: str | None):
+    """Download HF dataset split and store as 16k mono wav + manifest."""
+    kwargs = {}
+    if hf_token:
+        kwargs["token"] = hf_token
+    try:
+        ds = load_dataset(repo, split=split, streaming=False, **kwargs)
+    except Exception as exc:  # pragma: no cover - network path
+        print(f"[skip] {repo}:{split} -> {exc}")
+        return None
+
+    try:
+        ds = ds.cast_column("audio", Audio(sampling_rate=16000))
+    except Exception:
+        pass
+
+    name = f"{repo.replace('/', '___')}_{split}"
+    out_dir = out_root / name
+    audio_dir = out_dir / "audio"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest = out_dir / "manifest.jsonl"
+
+    kept = 0
+    with manifest.open("w", encoding="utf-8") as fo:
+        for i, row in enumerate(tqdm(ds, desc=f"{repo}:{split}")):
+            text = None
+            for key in ["text", "sentence", "transcript", "transcription", "label", "target"]:
+                if key in row and row[key]:
+                    text = str(row[key]).strip()
+                    break
+            if not text:
+                continue
+
+            if lang_regex:
+                lang_val = None
+                for lkey in ["lang", "language", "source_lang", "locale"]:
+                    if lkey in row and row[lkey]:
+                        lang_val = str(row[lkey]).lower()
+                        break
+                if lang_val and not lang_regex.search(lang_val):
+                    continue
+
+            audio = row.get("audio")
+            if not audio:
+                continue
+            arr = np.asarray(audio["array"])
+            sr = int(audio["sampling_rate"])
+            try:
+                arr, sr = ensure_wav_mono16k(arr, sr)
+            except Exception:
+                continue
+            dur = float(len(arr) / sr)
+            if not (MIN_DUR <= dur <= MAX_DUR):
+                continue
+
+            wav_path = audio_dir / f"{sha1_name(name + '_' + str(i))}.wav"
+            save_wav(wav_path, arr, sr)
+            item = {"audio_filepath": str(wav_path), "text": text, "duration": dur}
+            fo.write(json.dumps(item, ensure_ascii=False) + "\n")
+            kept += 1
+    print(f"[OK] {name}: {kept} records")
+    return {"name": name, "manifest": str(manifest), "dir": str(out_dir), "kept": kept}
+
+def main():
+    parser = argparse.ArgumentParser(description="Download HF dataset split to wav + manifest")
+    parser.add_argument("repo", help="HF dataset repo, e.g. nvidia/voice")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--out", default="data_wav", help="Output directory")
+    parser.add_argument("--hf-token", dest="hf_token", default=os.environ.get("HF_TOKEN"))
+    parser.add_argument("--lang-regex", dest="lang_regex", default="(^|[-_])ru([-_]|$)|russian")
+    args = parser.parse_args()
+
+    regex = re.compile(args.lang_regex, re.IGNORECASE) if args.lang_regex else None
+    prepare_hf_dataset_to_wav(args.repo, args.split, Path(args.out), regex, args.hf_token)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_dataset.py` to fetch HF datasets and convert audio to 16kHz WAV manifest for Canary
- add `canary_inference.py` to run Canary model and store predictions vs references
- add `dataset_analysis.py` computing WER and SER on the prediction set
- update README with usage instructions

## Testing
- `python -m py_compile download_dataset.py canary_inference.py dataset_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68c23568aa1c83269e5ec55bb4f604f6