### PR TITLE
Speed up dataset download with multithreaded audio processing

### DIFF
--- a/download_dataset.py
+++ b/download_dataset.py
@@ -9,6 +9,7 @@ import numpy as np
 import soundfile as sf
 from datasets import load_dataset, Audio
 from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 
 # ----- Настройки скачивания -----
 # Укажите здесь ссылку на набор данных Hugging Face (например "nvidia/voice")
@@ -45,9 +46,46 @@ def save_wav(path: Path, data: np.ndarray, sr: int):
     path.parent.mkdir(parents=True, exist_ok=True)
     sf.write(str(path), data, sr, subtype="PCM_16", format="WAV")
 
+
+def _process_row(i: int, row: dict, name: str, audio_dir: Path,
+                 lang_regex: re.Pattern | None):
+    text = None
+    for key in ["text", "sentence", "transcript", "transcription", "label", "target"]:
+        if key in row and row[key]:
+            text = str(row[key]).strip()
+            break
+    if not text:
+        return None
+
+    if lang_regex:
+        lang_val = None
+        for lkey in ["lang", "language", "source_lang", "locale"]:
+            if lkey in row and row[lkey]:
+                lang_val = str(row[lkey]).lower()
+                break
+        if lang_val and not lang_regex.search(lang_val):
+            return None
+
+    audio = row.get("audio")
+    if not audio:
+        return None
+    arr = np.asarray(audio["array"])
+    sr = int(audio["sampling_rate"])
+    try:
+        arr, sr = ensure_wav_mono16k(arr, sr)
+    except Exception:
+        return None
+    dur = float(len(arr) / sr)
+    if not (MIN_DUR <= dur <= MAX_DUR):
+        return None
+
+    wav_path = audio_dir / f"{sha1_name(name + '_' + str(i))}.wav"
+    save_wav(wav_path, arr, sr)
+    return {"audio_filepath": str(wav_path), "text": text, "duration": dur}
+
 def prepare_hf_dataset_to_wav(repo: str, split: str, out_root: Path,
                               lang_regex: re.Pattern | None, hf_token: str | None,
-                              cache_dir: Path | None = None):
+                              cache_dir: Path | None = None, num_workers: int = 10):
     """Download HF dataset split and store as 16k mono wav + manifest."""
     name = f"{repo.replace('/', '___')}_{split}"
     out_dir = out_root / name
@@ -76,43 +114,23 @@ def prepare_hf_dataset_to_wav(repo: str, split: str, out_root: Path,
     out_dir.mkdir(parents=True, exist_ok=True)
 
     kept = 0
-    with manifest.open("w", encoding="utf-8") as fo:
+    with manifest.open("w", encoding="utf-8") as fo, ThreadPoolExecutor(max_workers=num_workers) as ex:
+        futures = set()
         for i, row in enumerate(tqdm(ds, desc=f"{repo}:{split}")):
-            text = None
-            for key in ["text", "sentence", "transcript", "transcription", "label", "target"]:
-                if key in row and row[key]:
-                    text = str(row[key]).strip()
-                    break
-            if not text:
-                continue
-
-            if lang_regex:
-                lang_val = None
-                for lkey in ["lang", "language", "source_lang", "locale"]:
-                    if lkey in row and row[lkey]:
-                        lang_val = str(row[lkey]).lower()
-                        break
-                if lang_val and not lang_regex.search(lang_val):
-                    continue
-
-            audio = row.get("audio")
-            if not audio:
-                continue
-            arr = np.asarray(audio["array"])
-            sr = int(audio["sampling_rate"])
-            try:
-                arr, sr = ensure_wav_mono16k(arr, sr)
-            except Exception:
-                continue
-            dur = float(len(arr) / sr)
-            if not (MIN_DUR <= dur <= MAX_DUR):
-                continue
-
-            wav_path = audio_dir / f"{sha1_name(name + '_' + str(i))}.wav"
-            save_wav(wav_path, arr, sr)
-            item = {"audio_filepath": str(wav_path), "text": text, "duration": dur}
-            fo.write(json.dumps(item, ensure_ascii=False) + "\n")
-            kept += 1
+            futures.add(ex.submit(_process_row, i, row, name, audio_dir, lang_regex))
+            if len(futures) >= num_workers * 5:
+                done, futures = wait(futures, return_when=FIRST_COMPLETED)
+                for fut in done:
+                    item = fut.result()
+                    if item:
+                        fo.write(json.dumps(item, ensure_ascii=False) + "\n")
+                        kept += 1
+        done, _ = wait(futures)
+        for fut in done:
+            item = fut.result()
+            if item:
+                fo.write(json.dumps(item, ensure_ascii=False) + "\n")
+                kept += 1
     print(f"[OK] {name}: {kept} records")
     return {"name": name, "manifest": str(manifest), "dir": str(out_dir), "kept": kept}
 
@@ -128,12 +146,14 @@ def main():
     parser.add_argument("--lang-regex", dest="lang_regex", default="(^|[-_])ru([-_]|$)|russian")
     parser.add_argument("--cache-dir", dest="cache_dir", default=HF_CACHE_DIR,
                         help="HF datasets cache directory")
+    parser.add_argument("--workers", type=int, default=10,
+                        help="Number of concurrent workers for processing")
     args = parser.parse_args()
 
     regex = re.compile(args.lang_regex, re.IGNORECASE) if args.lang_regex else None
     cache_dir = Path(args.cache_dir) if args.cache_dir else None
     prepare_hf_dataset_to_wav(args.repo, args.split, Path(args.out), regex,
-                              args.hf_token, cache_dir)
+                              args.hf_token, cache_dir, args.workers)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Parallelize WAV generation using `ThreadPoolExecutor` to speed up dataset downloads
- Add `_process_row` helper and configurable `--workers` CLI option

## Testing
- `python download_dataset.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c23ca3ed688326bf0259f622086142