### PR TITLE
Allow configuring paths for Canary inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ python download_dataset.py <dataset_repo> --split <split> --out <out_dir> [--hf-
 The script downloads a HuggingFace dataset split, filters Russian samples, converts audio to 16kHz mono WAV and writes a `manifest.jsonl` file.
 
 ## 2. Run Canary inference
+Edit the path constants at the top of `canary_inference.py` to set the dataset
+directory, model and output location, then run:
+
 ```
-python canary_inference.py <manifest.jsonl> --out preds.jsonl
+python canary_inference.py
 ```
-Loads the Canary model and writes predictions vs reference text for each audio file.
+The script loads the Canary model and writes predictions vs reference text for each audio file.
 
 ## 3. Analyse predictions
 Edit the path constants at the top of `dataset_analysis.py` to select the


### PR DESCRIPTION
## Summary
- let `canary_inference.py` be configured via global constants for model, dataset folder and output directory
- update README to describe new configuration-based usage

## Testing
- `python -m py_compile canary_inference.py`


------
https://chatgpt.com/codex/tasks/task_e_68c242d657c08326a582d67b6757aebd