### PR TITLE
Improve download parallelism with thread workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ The script downloads a HuggingFace dataset split, filters Russian samples, conve
 | `--hf-token HF_TOKEN` | Hugging Face access token | env `HF_TOKEN` |
 | `--lang-regex LANG_REGEX` | Regex to match Russian samples | `(^|[-_])ru([-_]|$)|russian` |
 | `--cache-dir CACHE_DIR` | Datasets cache directory | `hf_cache` |
-| `--workers WORKERS` | Number of parallel processes | `10` |
+| `--workers WORKERS` | Number of parallel workers | `10` |
 | `--min-dur MIN_DUR` | Minimum audio duration (sec) | `1.0` |
 | `--max-dur MAX_DUR` | Maximum audio duration (sec) | `35.0` |
 | `--vad-mode VAD_MODE` | Aggressiveness of VAD (0–3) | `2` |
 | `--pause-sec PAUSE_SEC` | Minimum pause used for splitting | `0.3` |
-| `--chunk-size CHUNK_SIZE` | Rows processed per batch | `100` |
 
 ### Examples
 Download the `train` split of a public dataset:
@@ -32,11 +31,11 @@ Download the `train` split of a public dataset:
 python download_dataset.py nvidia/voice --split train --out data_voice
 ```
 
-Download with custom limits and batching:
+Download with custom limits:
 
 ```bash
 python download_dataset.py bond005/taiga_speech_v2 --min-dur 1 --max-dur 15 \
-    --chunk-size 200 --workers 4 --out taiga_subset
+    --workers 4 --out taiga_subset
 ```
 
 ## 2. Run Canary inference


### PR DESCRIPTION
## Summary
- use ThreadPoolExecutor to process dataset rows concurrently
- drop chunk-based batching and remove unused --chunk-size option
- document updated options in README

## Testing
- `python -m py_compile download_dataset.py`
- `python download_dataset.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c2dc4896308326a8cf9c9a4571b0d5