### PR TITLE
feat: add CLI options for canary inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,16 @@ python download_dataset.py bond005/taiga_speech_v2 --min-dur 1 --max-dur 15 \
 ```
 
 ## 2. Run Canary inference
-Edit the path constants at the top of `canary_inference.py` to set the dataset
-directory, model and output location, then run:
+`canary_inference.py` accepts command‑line options instead of hard‑coded paths.
+Paths are resolved relative to the script directory, so you can point to folders
+next to the script or provide absolute paths. Example:
 
 ```
-python canary_inference.py
+python canary_inference.py --dataset-dir data_wav --out-dir predictions
 ```
-The script loads the Canary model and writes predictions vs reference text for each audio file.
+
+Use `--help` to see all available options. The script loads the Canary model and
+writes predictions vs reference text for each audio file.
 
 ## 3. Analyse predictions
 Edit the path constants at the top of `dataset_analysis.py` to select the

--- a/canary_inference.py
+++ b/canary_inference.py
@@ -1,35 +1,63 @@
+from __future__ import annotations
+
+import argparse
 import json
 from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
-from nemo.collections.asr.models import ASRModel
 from tqdm import tqdm
 
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from nemo.collections.asr.models import ASRModel
 
-# configuration
-DATASET_DIR = Path("data_wav")
-OUT_DIR = Path("predictions")
-MODEL_ID = "nvidia/canary-1b-v2"
-NEMO_PATH: str | None = None
-SOURCE_LANG = "ru"
-TARGET_LANG = "ru"
-TASK = "asr"
-PNC = False
 
-# Batch settings
-BATCH_SIZE = 16
+# Base directory of the script, used for resolving relative paths
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def resolve_path(p: Path) -> Path:
+    """Resolve a path relative to the script directory if it is not absolute."""
+    return p if p.is_absolute() else (BASE_DIR / p).resolve()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Canary inference on a dataset")
+    parser.add_argument("--dataset-dir", type=Path, default=Path("data_wav"),
+                        help="Directory containing manifest.jsonl")
+    parser.add_argument("--out-dir", type=Path, default=Path("predictions"),
+                        help="Directory to save predictions")
+    parser.add_argument("--model-id", default="nvidia/canary-1b-v2",
+                        help="HuggingFace model identifier")
+    parser.add_argument("--nemo-path", type=str, default=None,
+                        help="Path to a local .nemo model file")
+    parser.add_argument("--source-lang", default="ru",
+                        help="Source language for inference")
+    parser.add_argument("--target-lang", default="ru",
+                        help="Target language for inference")
+    parser.add_argument("--task", default="asr",
+                        help="Task type for Canary model")
+    parser.add_argument("--pnc", action="store_true",
+                        help="Enable punctuation and casing")
+    parser.add_argument("--batch-size", type=int, default=16,
+                        help="Transcription batch size")
+    args = parser.parse_args()
+    args.dataset_dir = resolve_path(args.dataset_dir)
+    args.out_dir = resolve_path(args.out_dir)
+    return args
 
 
 def load_canary(model_id: str, nemo_path: str | None):
+    from nemo.collections.asr.models import ASRModel
+
     if nemo_path:
         return ASRModel.restore_from(nemo_path).eval()
     return ASRModel.from_pretrained(model_name=model_id).eval()
 
 
-def transcribe_paths(model: ASRModel, paths: List[str],
+def transcribe_paths(model: ASRModel, paths: List[str], batch_size: int,
                      source_lang: str, target_lang: str, task: str, pnc: bool):
     results = {}
-    batch_size = max(1, int(BATCH_SIZE))
+    batch_size = max(1, int(batch_size))
     import torch, gc
     for i in range(0, len(paths), batch_size):
         batch = paths[i:i + batch_size]
@@ -51,16 +79,18 @@ def transcribe_paths(model: ASRModel, paths: List[str],
     return results
 
 
-def main():
-    manifest = DATASET_DIR / "manifest.jsonl"
+def main() -> None:
+    args = parse_args()
+    manifest = args.dataset_dir / "manifest.jsonl"
     items = [json.loads(x) for x in manifest.open("r", encoding="utf-8")]
     uniq_paths = list({it["audio_filepath"] for it in items})
-    model = load_canary(MODEL_ID, NEMO_PATH)
-    preds = transcribe_paths(model, uniq_paths,
-                             SOURCE_LANG, TARGET_LANG, TASK, PNC)
+    model = load_canary(args.model_id, args.nemo_path)
+    preds = transcribe_paths(model, uniq_paths, args.batch_size,
+                             args.source_lang, args.target_lang,
+                             args.task, args.pnc)
 
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = OUT_DIR / "predictions.jsonl"
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.out_dir / "predictions.jsonl"
     with out_path.open("w", encoding="utf-8") as f:
         for it in tqdm(items, desc="write"):
             hyp = preds.get(it["audio_filepath"], "")


### PR DESCRIPTION
## Summary
- allow canary inference to accept both absolute and relative paths by resolving against script location
- expose model, dataset and output settings via argparse for easier configuration
- document new CLI usage

## Testing
- `python -m py_compile canary_inference.py`
- `python canary_inference.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c2eb7682308326a37b2b49d0ee4d21