### PR TITLE
fix: handle local Canary model path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Example:
 python canary_inference.py --dataset-dir data_wav --out-dir predictions
 ```
 
-The model location is hardcoded in the script. To use a different
-Hugging Face cache or `.nemo` file, edit the `MODEL_PATH` constant in
-`canary_inference.py`.
+The model cache is expected under `.hf/models--nvidia--canary-1b-v2`
+relative to the script. To use a different Hugging Face cache or `.nemo`
+file, edit the `MODEL_PATH` constant in `canary_inference.py`.
 
 Use `--help` to see all available options. The script loads the Canary model and
 writes predictions vs reference text for each audio file.

--- a/canary_inference.py
+++ b/canary_inference.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
 # Base directory of the script, used for resolving relative paths
 BASE_DIR = Path(__file__).resolve().parent
 
-# Hardcoded location of the Canary model files
-MODEL_PATH = Path("Z:/Users/GOW_PHD/lmstudio/models/Zapis_rolok/Finetuning_analysis/Ru_dataset_prep/STT_dataset_preparation_Ru/.hf/models--nvidia--canary-1b-v2")
+# Hardcoded relative location of the Canary model files
+MODEL_PATH = BASE_DIR / ".hf" / "models--nvidia--canary-1b-v2"
 
 
 def resolve_path(p: Path) -> Path:


### PR DESCRIPTION
## Summary
- hardcode local Canary model path for offline inference
- document how to change `MODEL_PATH` in `canary_inference.py`

## Testing
- `python -m py_compile canary_inference.py`
- `python canary_inference.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c2f36b7b488326bae87ae4ac034b89