### PR TITLE
Add TranscribeConfig override to transcription

### DIFF
--- a/canary_inference.py
+++ b/canary_inference.py
@@ -81,11 +81,22 @@ def transcribe_paths(model: ASRModel, paths: List[str], batch_size: int,
     results = {}
     batch_size = max(1, int(batch_size))
     import torch, gc
+    from nemo.collections.asr.models.config import TranscribeConfig
+
+    cfg = TranscribeConfig(batch_size=batch_size, num_workers=4)
+    # Adjust num_workers based on available hardware resources if needed
+    cfg.pretokenize = False
+
     for i in range(0, len(paths), batch_size):
         batch = paths[i:i + batch_size]
-        hyps = model.transcribe(batch, batch_size=batch_size,
-                                source_lang=source_lang, target_lang=target_lang,
-                                task=task, pnc=pnc)
+        hyps = model.transcribe(
+            batch,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            task=task,
+            pnc=pnc,
+            override_config=cfg,
+        )
         for p, h in zip(batch, hyps):
             if isinstance(h, str):
                 results[p] = h


### PR DESCRIPTION
## Summary
- use TranscribeConfig to control transcription batching
- disable pretokenization and set dataloader workers for model.transcribe

## Testing
- `python -m py_compile canary_inference.py`
- `python canary_inference.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c2fbc46b788326a1545feb80161b59