### PR TITLE
Add batch analysis over prediction directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,20 @@ Use `--help` to see all available options. The script loads the Canary model and
 writes predictions vs reference text for each audio file.
 
 ## 3. Analyse predictions
-Edit the path constants at the top of `dataset_analysis.py` to select the
-predictions file and output directory, then run:
+`dataset_analysis.py` resolves paths relative to the script directory and scans
+the `predictions/` folder for subdirectories. Each subfolder is expected to
+contain a `preds.jsonl` file with model outputs. For every dataset folder the
+script writes analysis results to `analysis_output/<dataset_name>/`.
 
 ```
-python dataset_analysis.py
+python dataset_analysis.py --preds-dir predictions --out-dir analysis_output
 ```
-The script computes WER, SER and semantic similarity for each utterance, splits
-the dataset into 30% easy and 70% difficult examples (after trimming outliers)
-and produces distribution plots.
+
+For each dataset the script computes WER, SER and semantic similarity for each
+utterance, splits the dataset into 30% easy and 70% difficult examples (after
+trimming outliers) and produces distribution plots. Use `--help` to see all
+options, including the `--tail-fraction` parameter that controls outlier
+trimming.
 
 The script depends on `sentence-transformers` and `matplotlib` which can be
 installed via pip:

--- a/dataset_analysis.py
+++ b/dataset_analysis.py
@@ -1,20 +1,55 @@
+from __future__ import annotations
+
+import argparse
 import json
 from pathlib import Path
 from typing import List
 
-import matplotlib.pyplot as plt
-import numpy as np
-from jiwer import wer
-from sentence_transformers import SentenceTransformer
-
-# configuration
-PREDICTIONS_PATH = Path("preds.jsonl")
-OUT_DIR = Path("analysis_output")
-TAIL_FRACTION = 0.05
+# configuration defaults
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_PREDS_DIR = Path("predictions")
+DEFAULT_OUT_DIR = Path("analysis_output")
+PRED_FILE_NAME = "preds.jsonl"
+DEFAULT_TAIL_FRACTION = 0.05
 
 
-def compute_semantic_similarity(refs: List[str], hyps: List[str]) -> np.ndarray:
+def resolve_path(p: Path) -> Path:
+    """Resolve ``p`` relative to the script directory if not absolute."""
+
+    return p if p.is_absolute() else (BASE_DIR / p).resolve()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyse prediction metrics")
+    parser.add_argument(
+        "--preds-dir",
+        type=Path,
+        default=DEFAULT_PREDS_DIR,
+        help="Directory containing prediction subfolders",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="Directory to store analysis results",
+    )
+    parser.add_argument(
+        "--tail-fraction",
+        type=float,
+        default=DEFAULT_TAIL_FRACTION,
+        help="Fraction of WER tail to drop at each end",
+    )
+    args = parser.parse_args()
+    args.preds_dir = resolve_path(args.preds_dir)
+    args.out_dir = resolve_path(args.out_dir)
+    return args
+
+
+def compute_semantic_similarity(refs: List[str], hyps: List[str]) -> "np.ndarray":
     """Return cosine similarity between reference and hypothesis texts."""
+
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
 
     model = SentenceTransformer("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
     emb_ref = model.encode(refs)
@@ -27,11 +62,15 @@ def compute_semantic_similarity(refs: List[str], hyps: List[str]) -> np.ndarray:
     return sims
 
 
-def main() -> None:
-    rows = []
+def analyse_dataset(pred_file: Path, out_dir: Path, tail_fraction: float) -> None:
+    import numpy as np
+    from jiwer import wer
+    import matplotlib.pyplot as plt
+
+    rows: List[dict] = []
     refs: List[str] = []
     hyps: List[str] = []
-    with PREDICTIONS_PATH.open("r", encoding="utf-8") as f:
+    with pred_file.open("r", encoding="utf-8") as f:
         for line in f:
             row = json.loads(line)
             ref = row.get("ref") or row.get("text") or ""
@@ -40,25 +79,21 @@ def main() -> None:
             refs.append(ref)
             hyps.append(hyp)
 
-    # Global metrics
     w = wer(refs, hyps) if refs else 0.0
     ser_flags = [ref.strip() != hyp.strip() for ref, hyp in zip(refs, hyps)]
     ser = float(np.mean(ser_flags)) if ser_flags else 0.0
 
-    # Per-sample metrics
     sample_wers = [wer([r], [h]) for r, h in zip(refs, hyps)]
     semantic_sims = compute_semantic_similarity(refs, hyps)
 
     for row, swer, sim, sf in zip(rows, sample_wers, semantic_sims, ser_flags):
         row.update({"wer": swer, "semantic": float(sim), "ser": int(sf)})
 
-    out_dir = OUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # Quantile analysis and split
     wers = np.array(sample_wers)
-    q_low = np.quantile(wers, TAIL_FRACTION)
-    q_high = np.quantile(wers, 1 - TAIL_FRACTION)
+    q_low = np.quantile(wers, tail_fraction)
+    q_high = np.quantile(wers, 1 - tail_fraction)
     filtered = [r for r in rows if q_low <= r["wer"] <= q_high]
     filtered.sort(key=lambda r: r["wer"])
     cut = int(len(filtered) * 0.3)
@@ -73,7 +108,6 @@ def main() -> None:
     write_jsonl(out_dir / "easy.jsonl", easy)
     write_jsonl(out_dir / "difficult.jsonl", difficult)
 
-    # Plots
     plt.figure()
     plt.hist(wers, bins=50)
     plt.axvline(q_low, color="red", linestyle="dashed")
@@ -100,6 +134,23 @@ def main() -> None:
     print(f"WER: {w:.4f}")
     print(f"SER: {ser:.4f}")
     print(f"Saved analysis to {out_dir}")
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.preds_dir.exists():
+        print(f"No predictions directory found at {args.preds_dir}")
+        return
+
+    for pred_dir in sorted(p for p in args.preds_dir.iterdir() if p.is_dir()):
+        pred_file = pred_dir / PRED_FILE_NAME
+        if not pred_file.exists():
+            print(f"Skipping {pred_dir.name}, missing {PRED_FILE_NAME}")
+            continue
+        out_dir = args.out_dir / pred_dir.name
+        print(f"Analyzing {pred_dir.name}...")
+        analyse_dataset(pred_file, out_dir, args.tail_fraction)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- iterate over each dataset subfolder in the predictions directory
- output per-dataset metrics under a matching analysis folder
- document the new `--preds-dir` option and default locations

## Testing
- `python dataset_analysis.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c2fafdf464832693727172d93f6214