### PR TITLE
Handle prediction objects with text fields

### DIFF
--- a/canary_inference.py
+++ b/canary_inference.py
@@ -97,6 +97,8 @@ def transcribe_paths(model: ASRModel, paths: List[str], batch_size: int,
                 results[p] = h
             elif isinstance(h, dict):
                 results[p] = h.get("text") or h.get("pred_text") or str(h)
+            elif hasattr(h, "text") or hasattr(h, "pred_text"):
+                results[p] = getattr(h, "text", getattr(h, "pred_text", str(h)))
             else:
                 results[p] = str(h)
         try:


### PR DESCRIPTION
## Summary
- handle prediction outputs that expose `text` or `pred_text` attributes
- ensure only plain text is written to `predictions.jsonl`

## Testing
- `python -m py_compile canary_inference.py`
- `python canary_inference.py` *(fails: FileNotFoundError: manifest.jsonl)*
- `python dataset_analysis.py` *(fails: No predictions directory found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30db9f9b083268566effc46c386ca