### PR TITLE
Handle missing tokens in Canary inference

### DIFF
--- a/canary_inference.py
+++ b/canary_inference.py
@@ -124,7 +124,10 @@ def transcribe_paths(
                 if token_logprobs:
                     conf = float(sum(token_logprobs) / len(token_logprobs))
                 elif score is not None:
-                    length = len(getattr(h, "tokens", getattr(h, "y_sequence", []))) or 1
+                    tokens = getattr(h, "tokens", None)
+                    if tokens is None:
+                        tokens = getattr(h, "y_sequence", []) or []
+                    length = len(tokens) or 1
                     conf = float(score) / length
             results[p] = {"text": text, "confidence": conf}
         try:


### PR DESCRIPTION
## Summary
- avoid `len(None)` when computing confidence scores

## Testing
- `python -m py_compile canary_inference.py`
- `python canary_inference.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c34d0ee7a88326b8a1fbcd68add1b8