### PR TITLE
feat: add targeted lora adapter layers

### DIFF
--- a/training/RUNPOD_CANARY_NEMO.md
+++ b/training/RUNPOD_CANARY_NEMO.md
@@ -1,5 +1,7 @@
 # Runpod: Canary LoRA (Native NeMo) — Quick Start
 
+All training scripts live under `/workspace/training`. Run commands from the
+repository root so the `training/` prefix resolves correctly.
 
 ## Start training (auto-download .nemo)
 
@@ -12,6 +14,7 @@ python training/runpod_nemo_canary_lora.py \
   --outdir /workspace/exp/canary_ru_lora_a6000 \
   --export /workspace/models/canary-ru-lora-a6000.nemo \
   --bs 8 --accum 1 --precision bf16 --num_workers 8 \
+  --adapter_name ru_lora --enc_lora_layers 6 --dec_lora_layers 2 \
   --lora_r 16 --lora_alpha 32 --lora_dropout 0.05
 ```
 
@@ -27,6 +30,7 @@ python training/runpod_nemo_canary_lora.py \
   --outdir /workspace/exp/canary_ru_lora_a6000 \
   --export /workspace/models/canary-ru-lora-a6000.nemo \
   --bs 8 --accum 1 --precision bf16 --num_workers 8 \
+  --adapter_name ru_lora --enc_lora_layers 6 --dec_lora_layers 2 \
   --resume /workspace/exp/canary_ru_lora_a6000/last.ckpt
 ```
 
@@ -44,7 +48,8 @@ python training/runpod_canary_launcher.py \
   --nemo /workspace/models/canary-1b-v2.nemo \
   --outdir /workspace/exp/canary_ru_lora \
   --export /workspace/models/canary-ru-lora.nemo \
-  --preset a6000-fast
+  --preset a6000-fast \
+  --adapter_name ru_lora --enc_lora_layers 6 --dec_lora_layers 2
 ```
 
 Or using an already unpacked folder:

--- a/training/runpod_canary_launcher.py
+++ b/training/runpod_canary_launcher.py
@@ -216,6 +216,9 @@ def main():
     ap.add_argument("--lora_r", type=int, default=16)
     ap.add_argument("--lora_alpha", type=int, default=32)
     ap.add_argument("--lora_dropout", type=float, default=0.05)
+    ap.add_argument("--enc_lora_layers", type=int, default=6, help="Number of top encoder layers to adapt")
+    ap.add_argument("--dec_lora_layers", type=int, default=2, help="Number of top decoder layers to adapt")
+    ap.add_argument("--adapter_name", default="ru_lora", help="LoRA adapter name")
 
     # Partial-specific overrides (optional)
     ap.add_argument("--unfreeze_encoder_last", type=int, default=4)
@@ -289,6 +292,9 @@ def main():
             "--lora_r", str(args.lora_r),
             "--lora_alpha", str(args.lora_alpha),
             "--lora_dropout", str(args.lora_dropout),
+            "--enc_lora_layers", str(args.enc_lora_layers),
+            "--dec_lora_layers", str(args.dec_lora_layers),
+            "--adapter_name", args.adapter_name,
         ]
     else:  # partial
         cmd = [


### PR DESCRIPTION
## Summary
- allow limiting LoRA to top encoder/decoder layers via `--enc_lora_layers` and `--dec_lora_layers`
- programmatically collect module names (linear_qkv, linear_proj, linear_fc1, linear_fc2) and build `LoRAConfig`
- fallback injection uses explicit module list so only selected layers get adapters
- launcher script exposes top-layer LoRA knobs and adapter name so dataset downloads work the same for partial or LoRA runs
- document where training scripts live and how to pass LoRA layer/adaptor options in quick-start guide

## Testing
- `python -m py_compile training/runpod_canary_launcher.py training/runpod_nemo_canary_lora.py`


------
https://chatgpt.com/codex/tasks/task_e_68c60e23503c83268c03aa7f9bae0a80